### PR TITLE
Added links to conductor, cadence and jBPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A curated list of awesome open source workflow engines
 ## Full fledged product
 * [Airflow](https://github.com/apache/incubator-airflow) - Python-based platform for running directed acyclic graphs (DAGs) of tasks
 * [Azkaban](https://azkaban.github.io/) - Batch workflow job scheduler created at LinkedIn to run Hadoop jobs.
+* [Cadence](https://github.com/uber/cadence) - An orchestration engine to execute asynchronous long-running business logic developed by Uber Engineering. 
 * [CloudSlang](http://www.cloudslang.io/) - Workflow engine to automate your DevOps use cases.
+* [Conductor](https://netflix.github.io/conductor/) - Netflix's Conductor is an orchestration engine that runs in the cloud.
 * [DigDag](https://www.digdag.io) - Digdag is a simple tool that helps you to build, run, schedule, and monitor complex pipelines of tasks.
 * [Fission Workflows](https://github.com/fission/fission-workflows) - A high-perfomant workflow engine for serverless functions on Kubernetes.
 * [Flor](https://github.com/floraison/flor) - A workflow engine written in Ruby. 
@@ -15,6 +17,9 @@ A curated list of awesome open source workflow engines
 * [RunDeck](http://rundeck.org/) - Job Scheduler and Runbook Automation.
 * [Workflow Engine](https://workflowengine.io) - A lightweight .NET and Java workflow engine.
 * [Workflow Core](https://github.com/danielgerlag/workflow-core) - Workflow Core is a light weight workflow engine targeting .NET Standard. 
+
+## BPM Suite
+* [jBPM](https://www.jbpm.org/) - The core of jBPM is a light-weight, extensible workflow engine written in pure Java that allows you to execute business processes using the latest BPMN 2.0 specification.
 
 ## SAAS
 * [Bip.io](https://bip.io/) - Web Automation For People And Robots.


### PR DESCRIPTION
I believe orchestration engines like conductor and cadence would be a nice addition to this list, as in a way they're workflow engines as well. Also added jBPM as a full BPM Suite which also provides a workflow engine on its core. 